### PR TITLE
I designed the Homepage screen, redesigned the Help screen, modified the scroll text code, and did a major code and comment clean-up.

### DIFF
--- a/TechEase.xcodeproj/project.pbxproj
+++ b/TechEase.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		3F0F5B06262BC97C00446AD2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3F0F5B05262BC97C00446AD2 /* Assets.xcassets */; };
 		3F0F5B09262BC97C00446AD2 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3F0F5B08262BC97C00446AD2 /* Preview Assets.xcassets */; };
 		3F6D5ECD2630C14600B6C7BB /* HelpScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6D5ECC2630C14600B6C7BB /* HelpScreen.swift */; };
+		3FEBDF45265076CD006C9F4C /* HelpButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEBDF44265076CD006C9F4C /* HelpButton.swift */; };
 		3FEF5180263CD94E00237755 /* NotificationsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEF517F263CD94E00237755 /* NotificationsScreen.swift */; };
 		5FA4B4A0264DCC2800C357C3 /* OverviewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA4B49F264DCC2800C357C3 /* OverviewScreen.swift */; };
 		5FB46C33263CBD4C008B809D /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB46C32263CBD4C008B809D /* CustomButton.swift */; };
@@ -33,6 +34,7 @@
 		3F0F5B08262BC97C00446AD2 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		3F0F5B0A262BC97C00446AD2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3F6D5ECC2630C14600B6C7BB /* HelpScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpScreen.swift; sourceTree = "<group>"; };
+		3FEBDF44265076CD006C9F4C /* HelpButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpButton.swift; sourceTree = "<group>"; };
 		3FEF517F263CD94E00237755 /* NotificationsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsScreen.swift; sourceTree = "<group>"; };
 		5FA4B49F264DCC2800C357C3 /* OverviewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverviewScreen.swift; sourceTree = "<group>"; };
 		5FB46C32263CBD4C008B809D /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
@@ -86,10 +88,10 @@
 				3F0F5B01262BC97B00446AD2 /* TechEaseApp.swift */,
 				3F0F5B03262BC97B00446AD2 /* ContentView.swift */,
 				5FB46C36263D9851008B809D /* DetailTutorial.swift */,
+				5FA4B49F264DCC2800C357C3 /* OverviewScreen.swift */,
 				3F0F5B05262BC97C00446AD2 /* Assets.xcassets */,
 				3F0F5B0A262BC97C00446AD2 /* Info.plist */,
 				3F0F5B07262BC97C00446AD2 /* Preview Content */,
-				5FA4B49F264DCC2800C357C3 /* OverviewScreen.swift */,
 			);
 			path = TechEase;
 			sourceTree = "<group>";
@@ -109,6 +111,7 @@
 				5FB46C39263D98FF008B809D /* TutorialModel.swift */,
 				5FB46C3F263D9A8D008B809D /* RoundedButton.swift */,
 				5FB46C41263DAB16008B809D /* ListOfTutorials.swift */,
+				3FEBDF44265076CD006C9F4C /* HelpButton.swift */,
 			);
 			path = ModelsAndCustomViews;
 			sourceTree = "<group>";
@@ -183,6 +186,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3FEF5180263CD94E00237755 /* NotificationsScreen.swift in Sources */,
+				3FEBDF45265076CD006C9F4C /* HelpButton.swift in Sources */,
 				5FFDE810262FABCB00ADEEDF /* SettingsScreen.swift in Sources */,
 				3F0F5B04262BC97B00446AD2 /* ContentView.swift in Sources */,
 				3F6D5ECD2630C14600B6C7BB /* HelpScreen.swift in Sources */,

--- a/TechEase/Accessibility.swift
+++ b/TechEase/Accessibility.swift
@@ -5,6 +5,7 @@
 //  Created by Natalman Nahm on 4/20/21.
 //  Modified by Arica Conrad on 5/1/21.
 //  Modified by Arica Conrad on 5/6/21.
+//  Modified by Arica Conrad on 5/15/21.
 //
 
 /*
@@ -21,23 +22,6 @@ struct Accessibility: View {
     var body: some View {
         
         VStack() {
-            
-            /*
-             
-             Arica: This is the placeholder title text. This can be removed when we have a top navigation menu.
-             
-             */
-            
-//            Text("Accessibility")
-//               .font(.largeTitle)
-//               .fontWeight(.regular)
-//               .frame(maxWidth: /*@START_MENU_TOKEN@*/.infinity/*@END_MENU_TOKEN@*/)
-//               .foregroundColor(Color("Black"))
-//               .padding()
-//               .border(/*@START_MENU_TOKEN@*/Color("DarkGreen")/*@END_MENU_TOKEN@*/, width: 2)
-//               .background(Color("LightGreen"))
-//               .padding()
-                            
             
             /*
              
@@ -70,6 +54,7 @@ struct Accessibility: View {
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .frame(width: 40, height: 40)
+                            .foregroundColor(Color("Black"))
                         Spacer()
                         Spacer()
                         Text("Text-to-Speech")
@@ -92,6 +77,7 @@ struct Accessibility: View {
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .frame(width: 40, height: 40)
+                            .foregroundColor(Color("Black"))
                         Spacer()
                         Spacer()
                         Text("Vision Options")
@@ -114,6 +100,7 @@ struct Accessibility: View {
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .frame(width: 40, height: 40)
+                            .foregroundColor(Color("Black"))
                         Spacer()
                         Spacer()
                         Text("Voice Commands")
@@ -130,18 +117,17 @@ struct Accessibility: View {
                 
             }
             
+            /*
             
-            // Arica: This Spacer is so the ZStack can be at the bottom of the screen.
-            Spacer()
+            Arica: This is the code for showing the scroll icon, scroll text, and Help Button. If a screen does not scroll, you can comment out the swipe icon and text.
+             
+             VERY IMPORTANT!
+             On a screen that does not scroll, also comment out the styling at the end of the ZStack. It is not needed if we just have the Help Button (and an outline looks kind of odd without the scroll text).
+             
+            */
             
-            // Arica: First, we make a ZStack. This allows the Help button to be an overlay on every screen, meaning the button is always visible, even when scrolling.
             ZStack {
-                
-                // Arica: Then, we make an HStack, as the button needs to be on the far right horizontally.
                 HStack {
-                    
-                    // Arica: This is for the scroll icon and text. For any screens that scroll, uncomment this code. Since the Accessibility screen does not have enough buttons to scroll, the code is commented out.
-                    
                     /*
                     HStack {
                         Image(systemName: "hand.draw")
@@ -149,6 +135,7 @@ struct Accessibility: View {
                             .aspectRatio(contentMode: .fit)
                             .frame(width: 40, height: 40)
                             .padding(10)
+                            .foregroundColor(Color("Black"))
                         Text("Swipe up or down to see more content.")
                             .font(.title3)
                             .foregroundColor(Color("Black"))
@@ -156,12 +143,9 @@ struct Accessibility: View {
                     }
                     .padding(10)
                     */
-                    
-                    
-                    // Arica: Then we use a Spacer to push the button to the far right.
+
                     Spacer()
                     
-                    // Arica: Then we use the button.
                     Button(action: /*@START_MENU_TOKEN@*/{}/*@END_MENU_TOKEN@*/, label: {
                         VStack {
                             Image(systemName: "questionmark")
@@ -176,6 +160,9 @@ struct Accessibility: View {
                     .buttonStyle(HelpButton())
                 }
             }
+            /*
+            .background(RoundedRectangle(cornerRadius: 0).stroke(Color("LightGray"), lineWidth: 4).background(Color("White")))
+            */
         }
         
         

--- a/TechEase/DetailTutorial.swift
+++ b/TechEase/DetailTutorial.swift
@@ -3,6 +3,7 @@
 //  TechEase
 //
 //  Created by Natalman Nahm on 5/1/21.
+//  Modified by Arica Conrad on 5/15/21.
 //
 
 import SwiftUI
@@ -26,6 +27,7 @@ struct viewDetailTutorial: View{
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 40, height: 40)
+                    .foregroundColor(Color("Black"))
                 Spacer()
                 Spacer()
                 Text(detailTutDisplay.TutorialName)

--- a/TechEase/HelpScreen.swift
+++ b/TechEase/HelpScreen.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Hans Mandt on 4/21/21.
 //  Modified by Arica Conrad on 5/6/21.
+//  Modified by Arica Conrad on 5/16/21.
 //
 
 import SwiftUI
@@ -30,7 +31,7 @@ struct HelpScreen: View {
             
             /*
             
-            Arica: The ScrollView encompasses the text, not the buttons. This allows the buttons to stay on the screen all the time. If we want the buttons to not stay on the screen, we can move the buttons back within the ScrollView.
+            Arica: The ScrollView encompasses the text and the "Contact Us" button, but not the swipe up or down text.
              
             */
             
@@ -53,7 +54,8 @@ struct HelpScreen: View {
                     
                 
                 Text("Tap the screen to press buttons. Swipe your finger up to scroll the page down, and swipe down to scroll the page up.")
-                    .font(.body)
+                    .foregroundColor(Color("Black"))
+                    .font(.title3)
                     .multilineTextAlignment(.leading)
                     .padding()
 
@@ -69,7 +71,8 @@ struct HelpScreen: View {
 
                 
                 Text("The Home button will take you back to the first screen (also known as the Home Screen) of this app. The back button will take you to the previous screen you were on.")
-                    .font(.body)
+                    .foregroundColor(Color("Black"))
+                    .font(.title3)
                     .multilineTextAlignment(.leading)
                     .padding()
                 
@@ -85,60 +88,97 @@ struct HelpScreen: View {
                     
                 
                 Text("Tutorials are grouped into categories. Selecting a tutorial category button will take you to a list of tutorials within that category. You can choose from the category list by tapping on one of the buttons to access that specific tutorial.")
-                    .font(.body)
+                    .foregroundColor(Color("Black"))
+                    .font(.title3)
                     .multilineTextAlignment(.leading)
                     .padding()
+                
+                /*
+                
+                Arica: The "Contact Us" button is still within the ScrollView, so the user will need to scroll to see the button.
+                 
+                */
+                
+                Button(action: /*@START_MENU_TOKEN@*/{}/*@END_MENU_TOKEN@*/) {
+                    HStack {
+                        Image(systemName: "envelope")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 40, height: 40)
+                            .foregroundColor(Color("Black"))
+                        Spacer()
+                        Spacer()
+                        Text("Contact Us")
+                            .font(.title2)
+                            .foregroundColor(Color("Black"))
+                        Spacer()
+                        Spacer()
+                        Spacer()
+                    }
+                }
+                .padding()
+                .buttonStyle(RoundedButton())
+                
+                
             }
-            
             
             /*
             
-            Arica: As mentioned above, the buttons are outside the ScrollView. If we don't want the buttons to always be on the screen, the buttons' code can be moved back inside the ScrollView.
+            Arica: This is the code for having both the scroll text and the Help Button be present together. The Help Button code is commented out because we are already on the Help screen.
+             
+             What the styling at the end of the ZStack does is it makes a light gray rectangle to outline our scroll text. I had to use the RoundedRectangle style, but I set the corner radius value to be zero so it still looks like a rectangle.
+             
+             @Hans Mandt
+             When you add the Help Button to each screen, please use the following code. If the screen scolls, please also include the code for the scroll icon and text.
              
             */
             
-            Button(action: /*@START_MENU_TOKEN@*/{}/*@END_MENU_TOKEN@*/) {
+            ZStack {
                 HStack {
-                    Image(systemName: "phone")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 40, height: 40)
+                    HStack {
+                        Image(systemName: "hand.draw")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 40, height: 40)
+                            .padding(10)
+                            .foregroundColor(Color("Black"))
+                        Text("Swipe up or down to see more content.")
+                            .font(.title3)
+                            .foregroundColor(Color("Black"))
+                            .multilineTextAlignment(.leading)
+                    }
+                    .padding(10)
+
                     Spacer()
-                    Spacer()
-                    Text("Contact Us")
-                        .font(.title2)
-                        .foregroundColor(Color("Black"))
-                    Spacer()
-                    Spacer()
-                    Spacer()
+                    
+                    /*
+                    Button(action: /*@START_MENU_TOKEN@*/{}/*@END_MENU_TOKEN@*/, label: {
+                        VStack {
+                            Image(systemName: "questionmark")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 40, height: 40)
+                            Text("Help")
+                                .font(.title2)
+                                .foregroundColor(Color("Black"))
+                        }
+                    })
+                    .buttonStyle(HelpButton())
+                    */
                 }
             }
-                .padding()
-                .buttonStyle(RoundedButton())
-            
-            
-            Button(action: {}) {
-                HStack {
-                    Image(systemName: "envelope")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 40, height: 40)
-                    Spacer()
-                    Spacer()
-                    Text("Email Us")
-                        .font(.title2)
-                        .foregroundColor(Color("Black"))
-                    Spacer()
-                    Spacer()
-                    Spacer()
-                }
-            }
-            .padding()
-            .buttonStyle(RoundedButton())
+            .background(RoundedRectangle(cornerRadius: 0).stroke(Color("LightGray"), lineWidth: 4).background(Color("White")))
         }
     }
 }
 
+/*
+
+Arica: I made a separate file for the Help Button code. In the unlikely event the code does not work, here is the code in its original location.
+ 
+*/
+
+/*
 struct HelpButton: ButtonStyle {
     func makeBody (configuration: Self.Configuration) -> some View {
         return configuration
@@ -151,7 +191,7 @@ struct HelpButton: ButtonStyle {
             .padding()
     }
 }
-
+*/
 
 struct HelpScreen_Previews:
     PreviewProvider {

--- a/TechEase/Homepage.swift
+++ b/TechEase/Homepage.swift
@@ -3,6 +3,7 @@
 //  TechEase
 //
 //  Created by Natalman Nahm on 4/30/21.
+//  Modified by Arica Conrad on 5/15/21.
 //
 
 import SwiftUI
@@ -16,20 +17,53 @@ struct Homepage: View {
     var body: some View {
         NavigationView{
             VStack(){
-                Text("Welcome!")
-                    .font(.system(size: 32.0))
-                    .foregroundColor(Color("DarkBlue"))
-                    .padding(.bottom)
-                    .padding(.top)
-                Text("Tap a button to access the tutorials or the settings. If you help, tap the help button in the bottom right corner.")
-                    .font(.title3)
+                
+                /*
+                 
+                Arica: This is the welcome title at the top of the screen.
+                 
+                 The reason the title text is in the HStack is because the Spacers seem to directly control the placement of the title. A VStack automatically centers the text, but I don't necessarily want to rely on that. Using the .multilineTextAlignment property has no effect on it, which is a bit concerning to me. That is why the title text is in an HStack (so we can directly control the placement of the title).
+                 
+                 If we want to change the placement of the title later, say, to the left, we can take out one Spacer and it works. Not doing it this way means we would not be able to do that.
+                 
+                 For any screen that does not use a title text like this, we do not need to use an HStack.
+                 
+                */
+                
+                HStack {
+                    Spacer()
+                    Text("Welcome!")
+                        .font(.title)
+                        .foregroundColor(Color("DarkBlue"))
+                    Spacer()
+                }
+                .padding()
+                    
+                /*
+                
+                Arica: This is the text that explains to the users what they can do on this screen.
+                 
+                FUTURE NOTE TO MYSELF:
+                Body text on the screens should use the ".title3" font size. Captions for photos should use the ".body" font size.
+                 
+                */
+                
+                
+                Text("Tap a button to access the tutorials or the settings. If you need help, tap the help button in the bottom right corner.")
                     .foregroundColor(Color("Black"))
+                    .font(.title3)
                     .multilineTextAlignment(.leading)
-                    .padding(10)
+                    .padding()
+                
+                /*
+                
+                Arica: These are the buttons that navigate to the tutorials and to the settings.
+                 
+                */
                 
                 NavigationLink(
                     destination: TechEaseTutorialList()){
-                    CustomButton(icon: "books.vertical", label: "Start Tutorial")
+                    CustomButton(icon: "book", label: "Start Tutorials")
                         .padding()
                 }
                 

--- a/TechEase/ModelsAndCustomViews/CustomButton.swift
+++ b/TechEase/ModelsAndCustomViews/CustomButton.swift
@@ -7,6 +7,7 @@
 //
 //  Modified by Arica Conrad on 5/1/21.
 //  Modified by Arica Conrad on 5/6/21.
+//  Modified by Arica Conrad on 5/15/21.
 //
 
 /**
@@ -25,6 +26,7 @@ struct CustomButton: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 40, height: 40)
+                .foregroundColor(Color("Black"))
             Spacer()
             Spacer()
             Text(label)

--- a/TechEase/ModelsAndCustomViews/HelpButton.swift
+++ b/TechEase/ModelsAndCustomViews/HelpButton.swift
@@ -1,0 +1,27 @@
+//
+//  HelpButton.swift
+//  TechEase
+//
+//  Created by Arica Conrad on 5/15/21.
+//
+
+/*
+
+Arica: This file contains the design code for the Help Button. This way, it is easily accessible. You still need to set up the icon for the button within each file, though. It might be possible to have all the code here, I'm not sure. The Accessibility.swift and the HelpScreen.swift files have the proper code.
+ 
+*/
+
+import SwiftUI
+
+struct HelpButton: ButtonStyle {
+    func makeBody (configuration: Self.Configuration) -> some View {
+        return configuration
+            .label
+            .frame(width: 100, height: 100)
+            .background(Color("LightYellow"))
+            .clipShape(/*@START_MENU_TOKEN@*/Circle()/*@END_MENU_TOKEN@*/)
+            .foregroundColor(.black)
+            .overlay(Circle().stroke(Color("DarkYellow"), lineWidth: 2))
+            .padding()
+    }
+}

--- a/TechEase/ModelsAndCustomViews/RoundedButton.swift
+++ b/TechEase/ModelsAndCustomViews/RoundedButton.swift
@@ -3,6 +3,7 @@
 //  TechEase
 //
 //  Created by Natalman Nahm on 5/1/21.
+//  Modified by Arica Conrad on 5/15/21.
 //
 
 import Foundation
@@ -18,6 +19,6 @@ struct RoundedButton: ButtonStyle {
             .padding()
             .frame(minWidth: /*@START_MENU_TOKEN@*/0/*@END_MENU_TOKEN@*/, maxWidth: /*@START_MENU_TOKEN@*/.infinity/*@END_MENU_TOKEN@*/)
             .background(RoundedRectangle(cornerRadius: 10).stroke(Color("DarkBlue"), lineWidth: 2).background(Color("LightBlue").cornerRadius(10)))
-            .foregroundColor(.black)
+            .foregroundColor(Color("Black"))
     }
 }

--- a/TechEase/NotificationsScreen.swift
+++ b/TechEase/NotificationsScreen.swift
@@ -13,22 +13,6 @@ struct NotificationsScreen: View {
             
             /*
              
-             Arica: This is the placeholder title text. This can be removed when we have a top navigation menu.
-             
-             */
-            
-//            Text("Notifications")
-//               .font(.largeTitle)
-//               .fontWeight(.regular)
-//               .frame(maxWidth: /*@START_MENU_TOKEN@*/.infinity/*@END_MENU_TOKEN@*/)
-//               .foregroundColor(Color("Black"))
-//               .padding()
-//               .border(/*@START_MENU_TOKEN@*/Color("DarkGreen")/*@END_MENU_TOKEN@*/, width: 2)
-//               .background(Color("LightGreen"))
-//               .padding()
-            
-            /*
-             
              Arica: This is the instructional text that describes if the user has any notifications right now. We had this screen in our Android app, so I thought it would be good to have here too. Above the text is the bell icon for notifications, and it is colored dark blue.
              
              */

--- a/TechEase/SettingsScreen.swift
+++ b/TechEase/SettingsScreen.swift
@@ -4,15 +4,12 @@
 //
 //  Created by Natalman Nahm on 4/20/21.
 //  Modified by Arica Conrad on 4/30/21 and 5/1/21.
+//  Modified by Arica Conrad on 5/15/21.
 //
 
 /*
  
- Arica: I cannot seem to get everything to go to the top of the screen. This seems to be a common issue, such as on the Homepage screen. I think it has to do with the NavigationView... I did not account for that.
- 
- FYI: THE BUTTONS DO NOT WORK!
- 
- @Natalman, if you could please hook up the button navigation, I would greatly appreciate that.
+ Arica:
  
  @Natalman, if you need your code as a reference, I left it commented out at the bottom of this file. I didn't want to delete it in case you needed it to look back to. If you in fact don't need the code, feel free to delete it. I left comments saying where your code starts and ends.
  
@@ -23,26 +20,8 @@ import SwiftUI
 struct SettingsScreen: View {
     var body: some View {
 
-            
             VStack() {
-                
-                /*
-                 
-                 Arica: This is the placeholder title text. This can be removed when we have a top navigation menu.
-                 
-                 */
-                
-//                Text("Settings")
-//                   .font(.largeTitle)
-//                   .fontWeight(.regular)
-//                   .frame(maxWidth: /*@START_MENU_TOKEN@*/.infinity/*@END_MENU_TOKEN@*/)
-//                   .foregroundColor(Color("Black"))
-//                   .padding()
-//                   .border(/*@START_MENU_TOKEN@*/Color("DarkGreen")/*@END_MENU_TOKEN@*/, width: 2)
-//                   .background(Color("LightGreen"))
-//                   .padding()
-                                
-                
+            
                 /*
                  
                  Arica: This is the instructional text that describes what the user can do on this screen.
@@ -60,13 +39,10 @@ struct SettingsScreen: View {
                 
                 /*
                  
-                 Arica: Even though we only have two buttons, I put everything in a ScrollView for good practice. I think this is what we will need to do from here on out.
-                 
-                 @Natalman, can you hook up the navigation for these buttons, please? For some reason, it isn't working for me... Is it the ScrollView? Is it the Button? Is it something else entirely? Your SettingsScreen file uses an overlay instead of a button for the Accessibility navigation. Is that why?
-                 
-                 The two screens you need are Accessibility.swift and NotificationsScreen.swift.
+                 Arica: These buttons navigate to the Accessibility and Notifications screens.
                  
                  */
+                
                 NavigationLink(destination: Accessibility()) {
                     CustomButton(icon: "figure.stand", label: "Accessibility")
                     .padding()
@@ -79,40 +55,6 @@ struct SettingsScreen: View {
                 }
                 
                 Spacer()
-                            
-                
-                /*
-                Arica: The following is sample ZStack code for the Help button.
-                */
-                
-                /*
-                ZStack {
-                    HStack {
-                        HStack {
-                            Image(systemName: "hand.draw")
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 40, height: 40)
-                                .padding(10)
-                            Text("Swipe up to see more tutorials.")
-                                .font(.title3)
-                                .foregroundColor(Color("Black"))
-                                .multilineTextAlignment(.leading)
-                        }
-                        
-                        Spacer()
-                        
-                        Button(action: {}) {
-                            Text("Help")
-                                .padding()
-                        }
-                        .background(Color("LightYellow"))
-                        .buttonStyle(HelpButton())
-                        .padding(10)
-                        
-                    }
-                }
-                */
             }
             .navigationBarTitle("Settings", displayMode: .inline)
             

--- a/TechEase/TechEaseApp.swift
+++ b/TechEase/TechEaseApp.swift
@@ -2,7 +2,7 @@
 //  TechEaseApp.swift
 //  TechEase
 //
-//  Created by Student Account on 4/17/21.
+//  Created by Arica Conrad, Mackenzie Fear, Hans Mandt, and Natalman Nahm on 4/17/21.
 //
 
 import SwiftUI

--- a/TechEase/TechEaseTutorialList.swift
+++ b/TechEase/TechEaseTutorialList.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Natalman Nahm on 4/20/21.
 //  Modified by Arica Conrad on 4/20/21.
+//  Modified by Arica Conrad on 5/15/21.
 //
 
 import SwiftUI
@@ -24,6 +25,7 @@ struct viewTutorial: View {
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 40, height: 40)
+                    .foregroundColor(Color("Black"))
                 Spacer()
                 Spacer()
                 Text(tutorialDisplay.TutorialName)
@@ -67,7 +69,7 @@ struct TechEaseTutorialList: View {
                             .padding()
                             .frame(minWidth: /*@START_MENU_TOKEN@*/0/*@END_MENU_TOKEN@*/, maxWidth: /*@START_MENU_TOKEN@*/.infinity/*@END_MENU_TOKEN@*/)
                             .background(RoundedRectangle(cornerRadius: 10).stroke(Color("DarkBlue"), lineWidth: 2).background(Color("LightBlue").cornerRadius(10)))
-                            .foregroundColor(.black)
+                            .foregroundColor(Color("Black"))
                     }
                     //.padding(.top, 0)
                     .listStyle(PlainListStyle())


### PR DESCRIPTION
#2 
#28 
#30 

I designed the Homepage screen to look more like our high-fidelity prototype. That involved more behind-the-scenes work and a grammar check. I had to make sure our design code was staying consistent for all the screens, including the Homepage.

I went back to the Help screen and modified its code to be more consistent with the rest of the app. I adjusted the scroll text's ZStack code to be a bit more differentiated on the screen, and I also added the scroll text to the Help screen (it was not there before).

I moved the OverviewScreen.swift file out of the PreviewContent folder. I do not know why the file was there. I also added a new file called HelpButton that has some of the stying code for the Help Button.

I did a major code and comment clean-up across the app. I deleted my comments that weren't needed or relevant anymore and also removed the placeholder titles from all screens except for the Help screen. I left that one there as a reminder that the navigation menu still needs to be implemented for that screen.